### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN chmod +x mainRecon/mainRecon.sh
 # Install go
 WORKDIR /tmp
 RUN \
-    wget -q https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz -O go.tar.gz && \
+    wget -q https://dl.google.com/go/go1.17.6.linux-amd64.tar.gz -O go.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz
 ENV GOPATH "/root/go"
 ENV PATH "$PATH:/usr/local/go/bin:$GOPATH/bin"
@@ -39,45 +39,43 @@ RUN mkdir tools \
 WORKDIR /tools/
 RUN \
     # Install findomain
-    wget --quiet https://github.com/Edu4rdSHL/findomain/releases/download/1.5.0/findomain-linux -O /tools/findomain/findomain && \
+    wget --quiet https://github.com/Findomain/Findomain/releases/download/5.1.1/findomain-linux -O /tools/findomain/findomain && \
     chmod +x /tools/findomain/findomain && \
     ln -s /tools/findomain/findomain /usr/bin/findomain && \
     # Install assetfinder
-    go get -u github.com/tomnomnom/assetfinder && \
+    go install github.com/tomnomnom/assetfinder@latest && \
     # Install amass
     wget --quiet https://github.com/OWASP/Amass/releases/download/v3.5.5/amass_v3.5.5_linux_amd64.zip -O /tools/amass/amass.zip && \
     unzip /tools/amass/amass.zip -d /tools/amass/ && \
     rm /tools/amass/amass.zip && \
     ln -s /tools/amass/amass_v3.5.5_linux_amd64/amass /usr/bin/amass && \
     # Install httprobe
-    go get -u github.com/tomnomnom/httprobe && \
+    go install github.com/tomnomnom/httprobe@latest && \
     # Install waybackurls
-    go get github.com/tomnomnom/waybackurls && \
+    go install github.com/tomnomnom/waybackurls@latest && \
     # Install aquatone
-    wget --quiet https://github.com/michenriksen/aquatone/releases/download/v1.7.0/aquatone_linux_amd64_1.7.0.zip -O /tools/aquatone/aquatone.zip && \
-    unzip /tools/aquatone/aquatone.zip -d /tools/aquatone/  && \
-    rm /tools/aquatone/aquatone.zip && \
-    ln -s /tools/aquatone/aquatone /usr/bin/aquatone && \
+    go get github.com/shelld3v/aquatone && \
+    ln -s /root/go/bin/aquatone /usr/bin/aquatone && \
     # Install Nez Zile
     git clone https://github.com/bonino97/new-zile.git && \
     pip3 install termcolor && \
     # Install Linkfinder
     git clone https://github.com/GerbenJavado/LinkFinder.git && \
     # Install waybackurls
-    go get github.com/tomnomnom/waybackurls && \
+    go install github.com/tomnomnom/waybackurls@latest && \
     # Install subfinder
-    go get github.com/projectdiscovery/subfinder/v2/cmd/subfinder && \
+    go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest && \
     # Install ParamSpider
     git clone https://github.com/devanshbatham/ParamSpider && \
     pip3 install -r ParamSpider/requirements.txt && \
     # Install Dirsearch
     git clone https://github.com/maurosoria/dirsearch.git && \
     # Install ffuf
-    go get github.com/ffuf/ffuf && \
+    go install github.com/ffuf/ffuf@latest && \
     # Install unfurl
-    go get -u github.com/tomnomnom/unfurl && \
+    go install github.com/tomnomnom/unfurl@latest && \
     # Install subjs
-    go get -u github.com/lc/subjs
+    go install github.com/lc/subjs@latest
 
 # Findomain configuration
 ENV findomain_fb_token="ENTER_TOKEN_HERE"

--- a/README.md
+++ b/README.md
@@ -129,8 +129,13 @@ Build your docker container
 
 After building the container using either way, run the following:
 
-    docker run --rm -it -v /path/to/local/directory:/mainData mainrecon -p [--program] <hackerone> -f [--file] targets.txt 
+**linux/amd64:**
 
+```docker run --rm -it -v /path/to/local/directory:/mainData mainrecon -p [--program] <hackerone> -f [--file] targets.txt```
+
+**Others (including Apple silicon):**
+
+```docker run --platform linux/amd64 --rm -it -v /path/to/local/directory:/mainData mainrecon -p [--program] <hackerone> -f [--file] targets.txt```
 
 ### Option 2 - Use the image from docker hub
 
@@ -150,7 +155,13 @@ There are differents use cases for use the image and you should know how to run 
 
   Share information from your local directory to container directory and save information on your local directory. You should save information under /mainData directory.
 
-        docker run --rm -it -v /path/to/local/directory:/mainData --name mainrecon l34r00t/mainrecon -p [--program] <hackerone> -f [--file] targets.txt 
+**linux/amd64:**
+
+```docker run --rm -it -v /path/to/local/directory:/mainData --name mainrecon l34r00t/mainrecon -p [--program] <hackerone> -f [--file] targets.txt```
+
+**Others (including Apple silicon):**
+
+```docker run --platform linux/amd64 --rm -it -v /path/to/local/directory:/mainData --name mainrecon l34r00t/mainrecon -p [--program] <hackerone> -f [--file] targets.txt```
 
 
 ### targets.txt

--- a/README.md
+++ b/README.md
@@ -119,7 +119,13 @@ Also, you can configure access token for run findomain. You must configure the D
 
 Build your docker container
 
-    docker build -t mainrecon .
+**linux/amd64:**
+
+```docker build -t mainrecon-master .```
+
+**Others (including Apple silicon):**
+
+```docker build --platform=linux/amd64 -t mainrecon .```
 
 After building the container using either way, run the following:
 


### PR DESCRIPTION
The main reason is [subfinder](https://github.com/projectdiscovery/subfinder/) is now requires **go1.17** to be installed successfully.

What's Changed:
==

* updated version of `go` and `findomain`.
* changed `aquatone` to [@shelld3v](https://github.com/shelld3v)'s [version](https://github.com/shelld3v/aquatone) since the [original one](https://github.com/michenriksen/aquatone) had been abandoned.
* updated `go get` to `go install` since moving to go1.17. Aquatone has not been updated since it didn't support `go install`.